### PR TITLE
Digital Ocean Reverse Proxy + Certbot SSL

### DIFF
--- a/deployment/digital-ocean.md
+++ b/deployment/digital-ocean.md
@@ -210,7 +210,7 @@ sudo ln -s /opt/certbot/bin/certbot /usr/bin/certbot
 sudo certbot --nginx
 ```
 
-5. After following the certificate generation wizard, we will be able to access our EC2 instance via HTTPS using the address `https://yourdomain.com`
+5. After following the certificate generation wizard, we will be able to access our Droplet via HTTPS using the address https://yourdomain.com
 
 ### Set up automatic renewal
 

--- a/deployment/digital-ocean.md
+++ b/deployment/digital-ocean.md
@@ -89,3 +89,137 @@ docker-compose stop
 docker pull flowiseai/flowise
 ```
 
+
+## Adding Reverse Proxy & SSL
+A reverse proxy is the recommended method to expose an application server to the internet.
+It will let us connect to our droplet using a URL alone instead of the server IP and port number. This provides security benefits in isolating the application server from direct internet access, the ability to centralize firewall protection, a minimized attack plane for common threats such as denial of service attacks, and most importantly for our purposes, the ability to terminate SSL/TLS encryption in a single place.
+> A lack of SSL on your Droplet will cause the embeddable widget and API endpoints to be inaccessible in modern browsers. This is because browsers have begun to deprecate HTTP in favor of HTTPS, and block HTTP requests from pages loaded over HTTPS.
+
+
+### Step 1 — Installing Nginx
+1. Nginx is available for installation with apt through the default repositories. Update your repository index, then install Nginx:
+
+```bash
+sudo apt update
+sudo apt install nginx
+```
+> Press Y to confirm the installation. If you are asked to restart services, press ENTER to accept the defaults.
+
+2. You need to allow access to Nginx through your firewall. Having set up your server according to the initial server prerequisites, add the following rule with ufw:
+
+```bash
+sudo ufw allow 'Nginx HTTP'
+```
+
+3. Now you can verify that Nginx is running:
+
+```bash
+systemctl status nginx
+```
+Output:
+```bash
+● nginx.service - A high performance web server and a reverse proxy server
+     Loaded: loaded (/lib/systemd/system/nginx.service; enabled; vendor preset: enabled)
+     Active: active (running) since Mon 2022-08-29 06:52:46 UTC; 39min ago
+       Docs: man:nginx(8)
+   Main PID: 9919 (nginx)
+      Tasks: 2 (limit: 2327)
+     Memory: 2.9M
+        CPU: 50ms
+     CGroup: /system.slice/nginx.service
+             ├─9919 "nginx: master process /usr/sbin/nginx -g daemon on; master_process on;"
+             └─9920 "nginx: worker process
+```
+Next you will add a custom server block with your domain and app server proxy.
+
+
+### Step 2 — Configuring your Server Block + DNS Record
+It is recommended practice to create a custom configuration file for your new server block additions, instead of editing the default configuration directly. 
+1. Create and open a new Nginx configuration file using nano or your preferred text editor:
+   
+```bash
+sudo nano /etc/nginx/sites-available/your_domain
+```
+
+2. Insert the following into your new file, making sure to replace `your_domain` with your own domain name:
+
+
+```
+server {
+    listen 80;
+    listen [::]:80;
+    server_name your_domain; #Example: demo.flowiseai.com
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+3. Save and exit, with `nano` you can do this by hitting `CTRL+O` then `CTRL+X`.
+
+4. Next, enable this configuration file by creating a link from it to the sites-enabled directory that Nginx reads at startup, making sure again to replace `your_domain` with your own domain name::
+```bash
+sudo ln -s /etc/nginx/sites-available/your_domain /etc/nginx/sites-enabled/
+```
+5. You can now test your configuration file for syntax errors:
+```bash
+sudo nginx -t
+```
+6. With no problems reported, restart Nginx to apply your changes:
+```bash
+sudo systemctl restart nginx
+```
+
+7. Go to your DNS provider, and add a new A record. Name will be your domain name, and value will be the Public IPv4 address from your droplet
+
+<figure><img src="../.gitbook/assets/image (3) (2).png" alt="" width="367"><figcaption></figcaption></figure>
+
+Nginx is now configured as a reverse proxy for your application server. You should now be able to open the app: http://yourdomain.com.
+
+### Step 3 — Installing Certbot for HTTPS (SSL)
+
+If you'd like to add a secure `https` connection to your Droplet like `https://yourdomain.com`, you'll need to do the following:
+
+1. For installing Certbot and enabling HTTPS on NGINX, we will rely on Python. So, first of all, let's set up a virtual environment:
+
+```bash
+apt install python3.10-venv
+sudo python3 -m venv /opt/certbot/
+sudo /opt/certbot/bin/pip install --upgrade pip
+```
+
+2. Afterwards, run this command to install Certbot:
+
+```bash
+sudo /opt/certbot/bin/pip install certbot certbot-nginx
+```
+
+3. Now, execute the following command to ensure that the `certbot` command can be run:
+
+```bash
+sudo ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+```
+
+4. Finally, run the following command to obtain a certificate and let Certbot automatically modify the NGINX configuration, enabling HTTPS:
+
+```bash
+sudo certbot --nginx
+```
+
+5. After following the certificate generation wizard, we will be able to access our EC2 instance via HTTPS using the address `https://yourdomain.com`
+
+### Set up automatic renewal
+
+To enable Certbot to automatically renew the certificates, it is sufficient to add a cron job by running the following command:
+
+```bash
+echo "0 0,12 * * * root /opt/certbot/bin/python -c 'import random; import time; time.sleep(random.random() * 3600)' && sudo certbot renew -q" | sudo tee -a /etc/crontab > /dev/null
+```
+
+## Congratulations!
+
+You have successfully setup Flowise on your Droplet, with SSL certificate on your domain [🥳](https://emojipedia.org/partying-face/)

--- a/deployment/digital-ocean.md
+++ b/deployment/digital-ocean.md
@@ -34,7 +34,7 @@ For Mac/Linux, follow this [guide](https://docs.digitalocean.com/products/drople
 2. ```
    sudo sh get-docker.sh
    ```
-3. Install docket-compose:
+3. Install docker-compose:
 
 ```
 sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/deployment/digital-ocean.md
+++ b/deployment/digital-ocean.md
@@ -182,7 +182,7 @@ Nginx is now configured as a reverse proxy for your application server. You shou
 
 ### Step 3 — Installing Certbot for HTTPS (SSL)
 
-If you'd like to add a secure `https` connection to your Droplet like `https://yourdomain.com`, you'll need to do the following:
+If you'd like to add a secure `https` connection to your Droplet like https://yourdomain.com, you'll need to do the following:
 
 1. For installing Certbot and enabling HTTPS on NGINX, we will rely on Python. So, first of all, let's set up a virtual environment:
 


### PR DESCRIPTION
updated the Digital Ocean documentation to include setting up `nginx` as a reverse proxy, and adding SSL with `cerbot`.

references:
- [How To Configure Nginx as a Reverse Proxy on Ubuntu 22.04](https://www.digitalocean.com/community/tutorials/how-to-configure-nginx-as-a-reverse-proxy-on-ubuntu-22-04) Published on September 15, 2022
- [AWS Documentation - FlowiseAI](https://docs.flowiseai.com/deployment/aws)