### PR TITLE
Fix mistake in the framework name

### DIFF
--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -8,7 +8,7 @@ description: Learn how Flowise integrates with the LlamaIndex framework
 
 [LlamaIndex](https://www.llamaindex.ai/) is a data framework for LLM applications to ingest, structure, and access private or domain-specific data. It has advanced retrieval techniques for designing RAG (Retrieval Augmented Generation) apps.
 
-Flowise complements LangIndex by offering a visual interface. Here, nodes are organized into distinct sections, making it easier to build workflows.
+Flowise complements LlamaIndex by offering a visual interface. Here, nodes are organized into distinct sections, making it easier to build workflows.
 
 ### LlamaIndex Sections:
 


### PR DESCRIPTION
Replaces `LangIndex` to `LlamaIndex`