### PR TITLE
Fix grammar mistakes

### DIFF
--- a/integrations/llamaindex/agents/README.md
+++ b/integrations/llamaindex/agents/README.md
@@ -8,7 +8,7 @@ description: LlamaIndex Agent Nodes
 
 By themselves, language models can't take actions - they just output text.
 
-Agents are systems that use an LLM as a reasoning enginer to determine which actions to take and what the inputs to those actions should be. The results of those actions can then be fed back into the agent and it determine whether more actions are needed, or whether it is okay to finish.
+Agents are systems that use an LLM as a reasoning engine to determine which actions to take and what the inputs to those actions should be. The results of those actions can then be fed back into the agent, and it determines whether more actions are needed, or whether it is okay to finish.
 
 ### Agent Nodes:
 


### PR DESCRIPTION
Fix grammar mistakes detected while reading the documentation:

`enginer` --> `engine`
`it determine` --> `it determines`

I also added a comma after `agent, and it ...`