### PR TITLE
Docs - Add example using LiteLLM Proxy with Flowise

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -229,6 +229,7 @@
       * [Weaviate](integrations/langchain/vector-stores/weaviate.md)
       * [Zep Collection - Open Source](integrations/langchain/vector-stores/zep-collection-open-source.md)
       * [Zep Collection - Cloud](integrations/langchain/vector-stores/zep-collection-cloud.md)
+  * [LiteLLM Proxy](integrations/litellm/README.md)
   * [LlamaIndex](integrations/llamaindex/README.md)
     * [Agents](integrations/llamaindex/agents/README.md)
       * [OpenAI Tool Agent](integrations/llamaindex/agents/openai-tool-agent.md)

--- a/integrations/litellm/README.md
+++ b/integrations/litellm/README.md
@@ -1,0 +1,57 @@
+---
+description: Learn how Flowise integrates with LiteLLM Proxy
+---
+
+# LiteLLM Proxy
+
+Use [LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) with Flowise to:
+
+- Load balance Azure OpenAI/LLM endpoints
+- Call 100+ LLMs in the OpenAI Format 
+- Use Virtual Keys to set budgets, rate limits and track usage
+
+## How to use LiteLLM Proxy with Flowise
+
+### Step 1: Define your LLM Models in the LiteLLM config.yaml file
+
+LiteLLM Requires a config with all your models defined - we will call this file `litellm_config.yaml`
+
+[Detailed docs on how to setup litellm config - here](https://docs.litellm.ai/docs/proxy/configs)
+
+```yaml
+model_list:
+  - model_name: gpt-4
+    litellm_params:
+      model: azure/chatgpt-v-2
+      api_base: https://openai-gpt-4-test-v-1.openai.azure.com/
+      api_version: "2023-05-15"
+      api_key: 
+  - model_name: gpt-4
+    litellm_params:
+      model: azure/gpt-4
+      api_key: 
+      api_base: https://openai-gpt-4-test-v-2.openai.azure.com/
+  - model_name: gpt-4
+    litellm_params:
+      model: azure/gpt-4
+      api_key: 
+      api_base: https://openai-gpt-4-test-v-2.openai.azure.com/
+```
+
+
+### Step 2. Start litellm proxy
+
+```shell
+docker run \
+    -v $(pwd)/litellm_config.yaml:/app/config.yaml \
+    -p 4000:4000 \
+    ghcr.io/berriai/litellm:main-latest \
+    --config /app/config.yaml --detailed_debug
+```
+
+On success, the proxy will start running on `http://localhost:4000/`
+
+### Step 3: Use the LiteLLM Proxy in Flowise
+
+In Flowise, specify the **standard OpenAI nodes (not the Azure OpenAI nodes)** -- this goes for **chat models, embeddings, llms -- everything**
+

--- a/integrations/litellm/README.md
+++ b/integrations/litellm/README.md
@@ -55,3 +55,6 @@ On success, the proxy will start running on `http://localhost:4000/`
 
 In Flowise, specify the **standard OpenAI nodes (not the Azure OpenAI nodes)** -- this goes for **chat models, embeddings, llms -- everything**
 
+- Set `BasePath` to LiteLLM Proxy URL (`http://localhost:4000` when running locally)
+- Set the following headers `Authorization: Bearer <your-litellm-master-key>`
+


### PR DESCRIPTION
## Doc - Add example on using Flowise with LiteLLM Proxy

Hi, I'm the maintainer of [LiteLLM](https://github.com/BerriAI/litellm) - made a PR to show how to use Flowise with LiteLLM Proxy

## Why use LiteLLM Proxy ? 
Use [LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) to:
- Load balance Azure OpenAI/LLM endpoints
- Call 100+ LLMs in the OpenAI Format 
- Use Virtual Keys to set budgets, rate limits and track usage

## Related issues:
 - https://github.com/FlowiseAI/Flowise/discussions/1457
 - https://github.com/FlowiseAI/Flowise/issues/2814
 - https://github.com/FlowiseAI/Flowise/issues/1863
