### PR TITLE
Update aws.md to clarify manual deploy option

### DIFF
--- a/en/configuration/deployment/aws.md
+++ b/en/configuration/deployment/aws.md
@@ -55,7 +55,7 @@ terraform apply
 terraform destroy
 ```
 
-## Launch EC2 Instance
+## Deploy Manualy Using EC2
 
 1. In the EC2 dashboard, click **Launch Instance**
 


### PR DESCRIPTION
Very small change.  

When I first read the documentation it took me a minute to realize that the Launch EC2 Instance instructions were not part of the Terraform instructions.  