### PR TITLE
docs: add Langfuse integration guide

### DIFF
--- a/en/using-flowise/analytics/README.md
+++ b/en/using-flowise/analytics/README.md
@@ -15,6 +15,19 @@ There are several analytic providers Flowise integrates with:
 * [Arize](https://arize.com/)
 * [Phoenix](https://phoenix.arize.com/)
 
+## Langfuse
+
+[Langfuse](https://langfuse.com) is an open source LLM engineering platform that helps teams trace API calls, monitor performance, and debug issues in their AI applications.
+
+With the native integration, you can use Flowise to quickly create complex LLM applications in no-code and then use Langfuse to monitor and improve them.
+
+The integration supports all use cases of Flowise, including: interactively in the UI, API, and embeds.
+
+{% embed url="https://youtu.be/iFsSW6HHoa0" %}
+
+You can optionally add `release` to tag the current version of the flow. You usually don't need to change the other options.
+
+
 ## Lunary
 
 [Lunary](https://lunary.ai/) is a monitoring and analytics platform for LLM chatbots.


### PR DESCRIPTION
This PR adds an embedded video on using the Langfuse integration. 