### PR TITLE
doc: add Kubernetes deployment guide with Helm chart options

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -56,7 +56,7 @@
     * [Elestio](https://elest.io/open-source/flowiseai)
     * [GCP](configuration/deployment/gcp.md)
     * [Hugging Face](configuration/deployment/hugging-face.md)
-    * [Kubernetes using Helm](https://artifacthub.io/packages/helm/cowboysysop/flowise)
+    * [Kubernetes using Helm](configuration/deployment/kubernetes.md)
     * [Northflank](https://northflank.com/stacks/deploy-flowiseai)
     * [Railway](configuration/deployment/railway.md)
     * [Render](configuration/deployment/render.md)

--- a/en/configuration/deployment/README.md
+++ b/en/configuration/deployment/README.md
@@ -38,4 +38,4 @@ This complexity, however, also grants greater flexibility and control over your 
 * [Azure](azure.md)
 * [DigitalOcean](digital-ocean.md)
 * [GCP](gcp.md)
-* [Kubernetes using Helm](https://artifacthub.io/packages/helm/cowboysysop/flowise)
+* [Kubernetes using Helm](kubernetes.md)

--- a/en/configuration/deployment/kubernetes.md
+++ b/en/configuration/deployment/kubernetes.md
@@ -1,0 +1,92 @@
+---
+description: Learn how to deploy Flowise on Kubernetes using Helm
+---
+
+# Kubernetes
+
+***
+
+Deploy Flowise on Kubernetes using community-maintained Helm charts.
+
+## HelmForge Chart
+
+[HelmForge](https://helmforge.dev) provides a Helm chart that supports both standalone and queue deployment modes.
+
+* Chart source: [github.com/helmforgedev/charts](https://github.com/helmforgedev/charts/tree/main/charts/flowise)
+* ArtifactHub: [artifacthub.io/packages/helm/helmforge/flowise](https://artifacthub.io/packages/helm/helmforge/flowise)
+
+### Prerequisites
+
+* A running Kubernetes cluster (v1.26+)
+* [Helm](https://helm.sh/docs/intro/install/) v3 installed
+
+### Install
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install flowise helmforge/flowise
+```
+
+Or install directly from the OCI registry:
+
+```bash
+helm install flowise oci://ghcr.io/helmforgedev/helm/flowise
+```
+
+### Standalone Mode (default)
+
+The default installation runs Flowise as a single Deployment with SQLite and local storage. This is suitable for evaluation and small workloads.
+
+### Queue Mode
+
+For scalable production deployments, enable queue mode with separate main and worker pods backed by Redis and PostgreSQL:
+
+```bash
+helm install flowise helmforge/flowise \
+  --set architecture=queue \
+  --set postgresql.enabled=true \
+  --set redis.enabled=true
+```
+
+Queue mode deploys:
+
+* **Main pod** — serves the web UI and API
+* **Worker pods** — process AI execution tasks from the Redis queue
+* **PostgreSQL** — persistent database (bundled subchart or external)
+* **Redis** — message queue (bundled subchart or external)
+
+### Ingress
+
+Enable ingress to expose the Flowise UI:
+
+```yaml
+# values.yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: flowise.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: flowise-tls
+      hosts:
+        - flowise.example.com
+```
+
+```bash
+helm install flowise helmforge/flowise -f values.yaml
+```
+
+For full configuration options and architecture details, see the [chart documentation](https://helmforge.dev/docs/charts/flowise).
+
+## Cowboysysop Chart
+
+An alternative community chart is available from [cowboysysop](https://artifacthub.io/packages/helm/cowboysysop/flowise).
+
+```bash
+helm repo add cowboysysop https://cowboysysop.github.io/charts/
+helm install flowise cowboysysop/flowise
+```

--- a/en/configuration/deployment/kubernetes.md
+++ b/en/configuration/deployment/kubernetes.md
@@ -12,8 +12,8 @@ Deploy Flowise on Kubernetes using community-maintained Helm charts.
 
 [HelmForge](https://helmforge.dev) provides a Helm chart that supports both standalone and queue deployment modes.
 
-* Chart source: [github.com/helmforgedev/charts](https://github.com/helmforgedev/charts/tree/main/charts/flowise)
-* ArtifactHub: [artifacthub.io/packages/helm/helmforge/flowise](https://artifacthub.io/packages/helm/helmforge/flowise)
+* Chart source: [HelmForge Charts on GitHub](https://github.com/helmforgedev/charts/tree/main/charts/flowise)
+* ArtifactHub: [Flowise chart on ArtifactHub](https://artifacthub.io/packages/helm/helmforge/flowise)
 
 ### Prerequisites
 
@@ -77,7 +77,7 @@ ingress:
 ```
 
 ```bash
-helm install flowise helmforge/flowise -f values.yaml
+helm upgrade --install flowise helmforge/flowise -f values.yaml
 ```
 
 For full configuration options and architecture details, see the [chart documentation](https://helmforge.dev/docs/charts/flowise).


### PR DESCRIPTION
## Summary

Adds a dedicated Kubernetes deployment page to the self-hosting documentation, replacing the external ArtifactHub link with a local guide covering available community Helm charts.

Related to FlowiseAI/Flowise#6111

## Changes

- **New file**: `en/configuration/deployment/kubernetes.md`
  - HelmForge chart: standalone mode (SQLite) and queue mode (Redis + PostgreSQL)
  - Cowboysysop chart: preserved as alternative option
  - Installation, queue mode configuration, and ingress examples
- **Updated**: `en/configuration/deployment/README.md` — changed Kubernetes link from external ArtifactHub URL to local `kubernetes.md`
- **Updated**: `en/SUMMARY.md` — same link update for sidebar navigation

## Notes

- Both charts are community-maintained, not affiliated with Flowise
- The existing cowboysysop reference is preserved alongside the new HelmForge chart
- Follows the same format as other deployment guides (AWS, Azure, GCP, etc.)