### PR TITLE
docs: fix typo in getting started guide

### DIFF
--- a/en/getting-started/README.md
+++ b/en/getting-started/README.md
@@ -9,7 +9,7 @@ Self-hosting requires more technical skill to set up an instance, back up the da
 ## Quick Start
 
 {% hint style="info" %}
-Pre-requisite: ensure [NodeJS](https://nodejs.org/en/download) is installed on machine. Node `v18.15.0` or `v20` and above is supported.
+Pre-requisite: ensure [NodeJS](https://nodejs.org/en/download) is installed on machine. Node `v18.15.0` or `v20+` is supported.
 {% endhint %}
 
 Install Flowise locally using NPM.

--- a/en/getting-started/README.md
+++ b/en/getting-started/README.md
@@ -4,7 +4,7 @@
 
 ## Cloud
 
-Self-hosting requires more technical skill to setup instance, backing up database and maintaning updates. If you aren't experienced at managing servers and just want to use the webapp, we recommend using [Flowise Cloud](https://cloud.flowiseai.com).
+Self-hosting requires more technical skill to setup instance, backing up database and maintaining updates. If you aren't experienced at managing servers and just want to use the webapp, we recommend using [Flowise Cloud](https://cloud.flowiseai.com).
 
 ## Quick Start
 

--- a/en/getting-started/README.md
+++ b/en/getting-started/README.md
@@ -4,7 +4,7 @@
 
 ## Cloud
 
-Self-hosting requires more technical skill to setup instance, backing up database and maintaining updates. If you aren't experienced at managing servers and just want to use the webapp, we recommend using [Flowise Cloud](https://cloud.flowiseai.com).
+Self-hosting requires more technical skill to set up an instance, back up the database, and maintain updates. If you aren't experienced at managing servers and just want to use the webapp, we recommend using [Flowise Cloud](https://cloud.flowiseai.com).
 
 ## Quick Start
 


### PR DESCRIPTION
Fixed a typo in the getting started documentation.

Changed:
- maintaning -> maintaining