### PR TITLE
docs: link Firecrawl to firecrawl.dev on the document loader page

### DIFF
--- a/en/integrations/langchain/document-loaders/firecrawl.md
+++ b/en/integrations/langchain/document-loaders/firecrawl.md
@@ -8,7 +8,7 @@ description: Load data from URL using FireCrawl.
 
 # FireCrawl Document Loader
 
-FireCrawl is a powerful web crawling and scraping service that provides advanced capabilities for extracting content from websites. This module enables loading and processing web content through the FireCrawl API.
+[FireCrawl](https://www.firecrawl.dev) is a powerful web crawling and scraping service that provides advanced capabilities for extracting content from websites. This module enables loading and processing web content through the FireCrawl API.
 
 This module provides a sophisticated web crawler that can:
 - Scrape single web pages
@@ -85,7 +85,7 @@ Each document contains:
   - Additional custom metadata
 
 ## Notes
-- Requires valid FireCrawl API key
+- Requires a valid [FireCrawl API key](https://www.firecrawl.dev/app/api-keys)
 - Supports multiple content formats
 - Handles rate limiting
 - Job status monitoring


### PR DESCRIPTION
Adds two links on `en/integrations/langchain/document-loaders/firecrawl.md`:
- the first brand mention in the intro paragraph → https://www.firecrawl.dev
- the "Requires valid FireCrawl API key" note → https://www.firecrawl.dev/app/api-keys

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)