### PR TITLE
docs: add ChatInception chat model page

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -119,6 +119,7 @@
       * [ChatGoogleGenerativeAI](integrations/langchain/chat-models/google-ai.md)
       * [Google VertexAI](integrations/langchain/chat-models/google-vertexai.md)
       * [ChatHuggingFace](integrations/langchain/chat-models/chathuggingface.md)
+      * [ChatInception](integrations/langchain/chat-models/chatinception.md)
       * [ChatLocalAI](integrations/langchain/chat-models/chatlocalai.md)
       * [ChatMistralAI](integrations/langchain/chat-models/mistral-ai.md)
       * [IBM Watsonx](integrations/langchain/chat-models/ibm-watsonx.md)

--- a/en/integrations/langchain/chat-models/README.md
+++ b/en/integrations/langchain/chat-models/README.md
@@ -20,6 +20,7 @@ Chat models take a list of messages as input and return a model-generated messag
 * [ChatGooglePaLM](broken-reference)
 * [Google VertexAI](google-vertexai.md)
 * [ChatHuggingFace](chathuggingface.md)
+* [ChatInception](chatinception.md)
 * [ChatLocalAI](chatlocalai.md)
 * [ChatMistralAI](mistral-ai.md)
 * [ChatOllama](chatollama.md)

--- a/en/integrations/langchain/chat-models/chatinception.md
+++ b/en/integrations/langchain/chat-models/chatinception.md
@@ -1,0 +1,28 @@
+---
+description: Wrapper around Inception Mercury diffusion LLMs (OpenAI-compatible API).
+---
+
+# ChatInception
+
+## Description
+[Inception](https://inceptionlabs.ai/) provides the Mercury family of diffusion LLMs, including **Mercury 2** — a fast reasoning model that supports tool calling and structured outputs. The API is OpenAI-compatible and served from `https://api.inceptionlabs.ai/v1`.
+
+## Prerequisite
+1. Create an account on the [Inception Platform](https://platform.inceptionlabs.ai/).
+2. Get your API key from the [Inception Platform dashboard](https://platform.inceptionlabs.ai/). New accounts include free tokens to get started.
+
+## Step by Step Guide
+1. **Chat Models** > Drag the **ChatInception** node.
+2. Create a new credential with your Inception API key.
+3. Select a **Model Name** (defaults to `mercury-2`).
+4. (Optional) Click **Additional Parameters** to configure **Reasoning Effort** (`instant`, `low`, `medium`, `high`), **Max Tokens**, **Streaming**, **Timeout**, or override the **Base Path**.
+
+## Reasoning Effort
+Mercury 2 is a reasoning model. Use the **Reasoning Effort** parameter to trade latency for depth:
+
+| Value | Behavior |
+| --- | --- |
+| `instant` | Lowest latency, no extended thinking |
+| `low` | Minimal reasoning |
+| `medium` | Balanced reasoning (default) |
+| `high` | Maximum reasoning for complex tasks |

--- a/en/integrations/langchain/chat-models/chatinception.md
+++ b/en/integrations/langchain/chat-models/chatinception.md
@@ -7,7 +7,7 @@ description: Wrapper around Inception Mercury diffusion LLMs (OpenAI-compatible 
 ## Description
 [Inception](https://inceptionlabs.ai/) provides the Mercury family of diffusion LLMs, including **Mercury 2** — a fast reasoning model that supports tool calling and structured outputs. The API is OpenAI-compatible and served from `https://api.inceptionlabs.ai/v1`.
 
-## Prerequisite
+## Prerequisites
 1. Create an account on the [Inception Platform](https://platform.inceptionlabs.ai/).
 2. Get your API key from the [Inception Platform dashboard](https://platform.inceptionlabs.ai/). New accounts include free tokens to get started.
 


### PR DESCRIPTION
Document the new Inception chat model integration and register it in the chat models nav (SUMMARY.md) and node list (README.md).
PR: https://github.com/FlowiseAI/Flowise/pull/6506