### PR TITLE
docs: add ChatEmpirioLabs chat model page

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -113,6 +113,7 @@
       * [Azure ChatOpenAI](integrations/langchain/chat-models/azure-chatopenai-1.md)
       * [NVIDIA NIM](integrations/langchain/chat-models/nvidia-nim.md)
       * [ChatCometAPI](integrations/langchain/chat-models/chatcometapi.md)
+      * [ChatEmpirioLabs](integrations/langchain/chat-models/chatempiriolabs.md)
       * [ChatAnthropic](integrations/langchain/chat-models/chatanthropic.md)
       * [ChatCohere](integrations/langchain/chat-models/chatcohere.md)
       * [Chat Fireworks](integrations/langchain/chat-models/chat-fireworks.md)

--- a/en/integrations/langchain/chat-models/README.md
+++ b/en/integrations/langchain/chat-models/README.md
@@ -15,6 +15,7 @@ Chat models take a list of messages as input and return a model-generated messag
 * [NIBittensorChat](broken-reference)
 * [ChatAnthropic](chatanthropic.md)
 * [ChatCohere](chatcohere.md)
+* [ChatEmpirioLabs](chatempiriolabs.md)
 * [Chat Fireworks](chat-fireworks.md)
 * [ChatGoogleGenerativeAI](google-ai.md)
 * [ChatGooglePaLM](broken-reference)

--- a/en/integrations/langchain/chat-models/chatempiriolabs.md
+++ b/en/integrations/langchain/chat-models/chatempiriolabs.md
@@ -1,0 +1,20 @@
+---
+description: Wrapper around EmpirioLabs chat models that use the OpenAI compatible Chat endpoint.
+---
+
+# ChatEmpirioLabs
+
+## Description
+[EmpirioLabs](https://empiriolabs.ai) is a unified inference platform that provides access to frontier chat models such as Qwen3.7, DeepSeek V4, GLM-5.1, Kimi K2.7 Code, and MiniMax M3 through a single OpenAI compatible API. The ChatEmpirioLabs node lists the available chat models for you and streams responses out of the box.
+
+## Prerequisite
+1. Refer to the official [EmpirioLabs documentation](https://docs.empiriolabs.ai).
+2. Create an API key from your [EmpirioLabs dashboard](https://platform.empiriolabs.ai/dashboard/api-keys).
+
+## Step by Step Guide
+1. **Chat Models** > Drag the **ChatEmpirioLabs** node.
+2. Create a new credential with your EmpirioLabs API key.
+3. Pick a model from the **Model Name** list (for example `qwen3-7-plus`, `deepseek-v4-pro`, `glm-5-1`, or `kimi-k2-7-code`). The list is populated from the EmpirioLabs models catalog.
+4. (Optional) Click **Additional Parameters** to adjust Max Tokens, Top Probability, penalties, Timeout, or to override the Base Path.
+
+The node connects to the EmpirioLabs API at `https://api.empiriolabs.ai/v1`, so any model available on your account can be used the same way you would use any other OpenAI compatible Chat Model in Flowise.


### PR DESCRIPTION
## What
Adds a documentation page for the new **ChatEmpirioLabs** chat model node (a wrapper around the EmpirioLabs OpenAI compatible Chat endpoint).

## Changes
- `en/integrations/langchain/chat-models/chatempiriolabs.md` (new): description, prerequisites, and a step by step setup guide for the ChatEmpirioLabs node. Mirrors the existing `chatcometapi.md` page structure.
- `en/SUMMARY.md`: register the page in the LangChain Chat Models navigation.
- `en/integrations/langchain/chat-models/README.md`: add the page to the Chat Model Nodes list.

## Related
Documents the node added in FlowiseAI/Flowise#6509 (companion code PR).

EmpirioLabs is a unified inference platform exposing frontier chat models through one OpenAI compatible API. The node and credential follow the same pattern as the existing ChatCometAPI / Cerebras integrations.
