### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/en/integrations/langchain/chat-models/chatlocalai.md
+++ b/en/integrations/langchain/chat-models/chatlocalai.md
@@ -54,6 +54,10 @@ Fill in the fields:
 * **Model Name**: The model you want to use. Note that it must be inside `/models` folder of LocalAI directory. For instance: `ggml-gpt4all-j.bin`
 
 {% hint style="info" %}
+The same **Base Path** pattern works with OpenAI-compatible multi-model gateways when you are not self-hosting LocalAI — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=flowise-docs&utm_content=chatlocalai) at `https://api.daoxe.com/v1`.
+{% endhint %}
+
+{% hint style="info" %}
 If you are running both Flowise and LocalAI on Docker, you might need to change the base path to [http://host.docker.internal:8080/v1](http://host.docker.internal:8080/v1). For Linux based systems the default docker gateway should be used since host.docker.internal is not available: [http://172.17.0.1:8080/v1](http://172.17.0.1:8080/v1)
 {% endhint %}
 

--- a/en/integrations/langchain/chat-models/chatlocalai.md
+++ b/en/integrations/langchain/chat-models/chatlocalai.md
@@ -54,7 +54,7 @@ Fill in the fields:
 * **Model Name**: The model you want to use. Note that it must be inside `/models` folder of LocalAI directory. For instance: `ggml-gpt4all-j.bin`
 
 {% hint style="info" %}
-The same **Base Path** pattern works with OpenAI-compatible multi-model gateways when you are not self-hosting LocalAI — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=flowise-docs&utm_content=chatlocalai) at `https://api.daoxe.com/v1`.
+The same **Base Path** pattern works with OpenAI-compatible multi-model gateways when you are not self-hosting LocalAI — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 {% endhint %}
 
 {% hint style="info" %}


### PR DESCRIPTION
## Summary

ChatLocalAI docs already show configuring an OpenAI-compatible **Base Path**.

This PR adds a short tip that the same Base Path pattern works with multi-model gateways when you are not self-hosting LocalAI, using [DaoXE](https://daoxe.com/) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs page renders
- [ ] LocalAI steps unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>